### PR TITLE
WF-924506-Trademark_Symbol_Inclusion_UWP

### DIFF
--- a/uwp/Diagram/Annotation.md
+++ b/uwp/Diagram/Annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Annotation in UWP Diagram control | Syncfusion®
-description: Learn here all about Annotation support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Annotation support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Annotation.md
+++ b/uwp/Diagram/Annotation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Annotation in UWP Diagram control | Syncfusion
-description: Learn here all about Annotation support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Annotation in UWP Diagram control | Syncfusion®
+description: Learn here all about Annotation support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/AutoScroll.md
+++ b/uwp/Diagram/AutoScroll.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: AutoScroll in UWP Diagram control | Syncfusion®
-description: Learn here all about AutoScroll support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about AutoScroll support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/AutoScroll.md
+++ b/uwp/Diagram/AutoScroll.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: AutoScroll in UWP Diagram control | Syncfusion
-description: Learn here all about AutoScroll support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: AutoScroll in UWP Diagram control | Syncfusion®
+description: Learn here all about AutoScroll support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Automatic-Layouts.md
+++ b/uwp/Diagram/Automatic-Layouts.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Automatic Layouts in UWP Diagram control | Syncfusion
-description: Learn here all about Automatic Layouts support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Automatic Layouts in UWP Diagram control | Syncfusion®
+description: Learn here all about Automatic Layouts support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Automatic-Layouts.md
+++ b/uwp/Diagram/Automatic-Layouts.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Automatic Layouts in UWP Diagram control | Syncfusion®
-description: Learn here all about Automatic Layouts support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Automatic Layouts support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Commands.md
+++ b/uwp/Diagram/Commands.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Commands in UWP Diagram control | Syncfusion®
-description: Learn here all about Commands support in the Syncfusion® UWP Diagram (SfDiagram) control and more.  
+description: Learn here all about different types of commands supported in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Commands.md
+++ b/uwp/Diagram/Commands.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Commands in UWP Diagram control | Syncfusion®
-description: Learn here all about Commands support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Commands support in the Syncfusion® UWP Diagram (SfDiagram) control and more.  
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Commands.md
+++ b/uwp/Diagram/Commands.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Commands in UWP Diagram control | Syncfusion
-description: Learn here all about Commands support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Commands in UWP Diagram control | Syncfusion®
+description: Learn here all about Commands support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Connector.md
+++ b/uwp/Diagram/Connector.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Connector in UWP Diagram control | Syncfusion®
-description: Learn here all about Connector support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
+description: Learn here all about Connector support in the Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Connector.md
+++ b/uwp/Diagram/Connector.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Connector in UWP Diagram control | Syncfusion
-description: Learn here all about Connector support in Syncfusion UWP Diagram (SfDiagram) control, its elements, and more.
+title: Connector in UWP Diagram control | Syncfusion®
+description: Learn here all about Connector support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Constraints.md
+++ b/uwp/Diagram/Constraints.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Constraints in UWP Diagram control | Syncfusion
-description: Learn here all about Constraints support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Constraints in UWP Diagram control | Syncfusion®
+description: Learn here all about Constraints support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Constraints.md
+++ b/uwp/Diagram/Constraints.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Constraints in UWP Diagram control | Syncfusion®
-description: Learn here all about Constraints support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Constraints support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Context-Menu.md
+++ b/uwp/Diagram/Context-Menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Context Menu in UWP Diagram control | Syncfusion®
-description: Learn here all about Context Menu support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Context Menu support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Context-Menu.md
+++ b/uwp/Diagram/Context-Menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Context Menu in UWP Diagram control | Syncfusion
-description: Learn here all about Context Menu support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Context Menu in UWP Diagram control | Syncfusion®
+description: Learn here all about Context Menu support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/DataSource.md
+++ b/uwp/Diagram/DataSource.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: DataSource in UWP Diagram control | Syncfusion
-description: Learn here all about DataSource settings support and its declaration in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: DataSource in UWP Diagram control | Syncfusion®
+description: Learn here all about DataSource settings support and its declaration in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/DataSource.md
+++ b/uwp/Diagram/DataSource.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: DataSource in UWP Diagram control | Syncfusion®
-description: Learn here all about DataSource settings support and its declaration in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about DataSource settings support and its declaration in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Getting-Started.md
+++ b/uwp/Diagram/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Getting Started with UWP Diagram control | Syncfusion®
-description: Learn here about getting started with Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
+description: Learn here about getting started with the Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Getting-Started.md
+++ b/uwp/Diagram/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Diagram control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Diagram (SfDiagram) control, its elements and more.
+title: Getting Started with UWP Diagram control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
 platform: uwp
 control: SfDiagram
 documentation: ug
@@ -31,7 +31,7 @@ In order to add control manually in XAML, do the below steps:
 2. Import SfDiagram control namespace  Syncfusion.UI.Xaml.Diagram in XAML page.
 3. Declare SfDiagram control in XAML page.
 
-N> Starting with v16.2.0.x, if you reference Syncfusion assemblies from trial setup or from the NuGet feed, you also have to include a license key in your projects. Please refer to this [link](https://help.syncfusion.com/common/essential-studio/licensing/overview) to know about registering Syncfusion license key in your UWP application to use our components.
+N> Starting with v16.2.0.x, if you reference Syncfusion® assemblies from trial setup or from the NuGet feed, you also have to include a license key in your projects. Please refer to this [link](https://help.syncfusion.com/common/essential-studio/licensing/overview) to know about registering Syncfusion® license key in your UWP application to use our components.
     
 {% tabs %}
 {% highlight xaml %}

--- a/uwp/Diagram/Gridlines.md
+++ b/uwp/Diagram/Gridlines.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Gridlines in UWP Diagram control | Syncfusion®
-description: Learn here all about Gridlines support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
+description: Learn here all about Gridlines support in the Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Gridlines.md
+++ b/uwp/Diagram/Gridlines.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Gridlines in UWP Diagram control | Syncfusion
-description: Learn here all about Gridlines support in Syncfusion UWP Diagram (SfDiagram) control, its elements, and more.
+title: Gridlines in UWP Diagram control | Syncfusion®
+description: Learn here all about Gridlines support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Group.md
+++ b/uwp/Diagram/Group.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Group in UWP Diagram control | Syncfusion®
-description: Learn here all about Group support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
+description: Learn here all about Group support in the Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Group.md
+++ b/uwp/Diagram/Group.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Group in UWP Diagram control | Syncfusion
-description: Learn here all about Group support in Syncfusion UWP Diagram (SfDiagram) control, its elements, and more.
+title: Group in UWP Diagram control | Syncfusion®
+description: Learn here all about Group support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Interaction.md
+++ b/uwp/Diagram/Interaction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Interaction in UWP Diagram control | Syncfusion
-description: Learn here all about Interaction support in Syncfusion UWP Diagram (SfDiagram) control, its elements, and more.
+title: Interaction in UWP Diagram control | Syncfusion®
+description: Learn here all about Interaction support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Interaction.md
+++ b/uwp/Diagram/Interaction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Interaction in UWP Diagram control | Syncfusion®
-description: Learn here all about Interaction support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
+description: Learn here all about Interaction support in the Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Localization.md
+++ b/uwp/Diagram/Localization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Localization in UWP Diagram control | Syncfusion®
-description: Learn here all about Localization support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Localization support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Localization.md
+++ b/uwp/Diagram/Localization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Localization in UWP Diagram control | Syncfusion
-description: Learn here all about Localization support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Localization in UWP Diagram control | Syncfusion®
+description: Learn here all about Localization support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Node.md
+++ b/uwp/Diagram/Node.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Node in UWP Diagram control | Syncfusion®
-description: Learn here all about Node support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
+description: Learn here all about Node support in the Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Node.md
+++ b/uwp/Diagram/Node.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Node in UWP Diagram control | Syncfusion
-description: Learn here all about Node support in Syncfusion UWP Diagram (SfDiagram) control, its elements, and more.
+title: Node in UWP Diagram control | Syncfusion®
+description: Learn here all about Node support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Overview-Control.md
+++ b/uwp/Diagram/Overview-Control.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Diagram Overview control | Syncfusion
-description: Learn here all about Overview Control support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: About UWP Diagram Overview control | Syncfusion®
+description: Learn here all about Overview Control support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug
@@ -28,7 +28,7 @@ Steps to add Overview control manually in XAML:
 
 1. Add the following required assembly reference to the project, `Syncfusion.SfDiagram.UWP`
 
-2. Import Syncfusion WPF schema `http://schemas.syncfusion.com/uwp` or SfDiagram control namespace `Syncfusion.UI.Xaml.Diagram.Controls` in XAML page.
+2. Import Syncfusion® WPF schema `http://schemas.syncfusion.com/uwp` or SfDiagram control namespace `Syncfusion.UI.Xaml.Diagram.Controls` in XAML page.
 
 3. Declare Overview control in XAML page.
 

--- a/uwp/Diagram/Overview-Control.md
+++ b/uwp/Diagram/Overview-Control.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: About UWP Diagram Overview control | Syncfusion®
-description: Learn here all about Overview Control support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Overview Control support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Overview.md
+++ b/uwp/Diagram/Overview.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # UWP Diagram (SfDiagram) Overview
 
-**Essential Diagram UWP** creates rich Visio like applications. Its Framework comprises of many Elements that helps you to create an application easily. The rich feature set of the Diagram control includes Snapping, Guidelines, Gridlines, Serialization and Zooming.
+**Essential® Diagram UWP** creates rich Visio like applications. Its Framework comprises of many Elements that helps you to create an application easily. The rich feature set of the Diagram control includes Snapping, Guidelines, Gridlines, Serialization and Zooming.
 
 ![UWP SfDiagram Overview Image](Overview_images/Overview_img1.jpeg)
 

--- a/uwp/Diagram/Overview.md
+++ b/uwp/Diagram/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Diagram control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Diagram (SfDiagram) control, its elements and more.
+title: About UWP Diagram control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Overview.md
+++ b/uwp/Diagram/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: About UWP Diagram control | Syncfusion®
-description: Learn here all about introduction of Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
+description: Learn here all about introduction of the Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Page-Settings.md
+++ b/uwp/Diagram/Page-Settings.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Page Settings in UWP Diagram control | Syncfusion®
-description: Learn here all about Page Settings support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Page Settings support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Page-Settings.md
+++ b/uwp/Diagram/Page-Settings.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Page Settings in UWP Diagram control | Syncfusion
-description: Learn here all about Page Settings support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Page Settings in UWP Diagram control | Syncfusion®
+description: Learn here all about Page Settings support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Port.md
+++ b/uwp/Diagram/Port.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Port in UWP Diagram control | Syncfusion
-description: Learn here all about Port support in Syncfusion UWP Diagram (SfDiagram) control, its elements, and more.
+title: Port in UWP Diagram control | Syncfusion®
+description: Learn here all about Port support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Port.md
+++ b/uwp/Diagram/Port.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Port in UWP Diagram (SfDiagram)
 
-Essential Diagram for UWP provides support to define custom ports for making connections.
+Essential® Diagram for UWP provides support to define custom ports for making connections.
 
 ![Node Port](Port_images/Port_img1.jpeg)![Connector Port](Port_images/Port_img2.jpeg)
 

--- a/uwp/Diagram/Port.md
+++ b/uwp/Diagram/Port.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Port in UWP Diagram control | Syncfusion®
-description: Learn here all about Port support in Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
+description: Learn here all about Port support in the Syncfusion® UWP Diagram (SfDiagram) control, its elements, and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Rulers.md
+++ b/uwp/Diagram/Rulers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Rulers in UWP Diagram control | Syncfusion
-description: Learn here all about Rulers support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Rulers in UWP Diagram control | Syncfusion®
+description: Learn here all about Rulers support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Rulers.md
+++ b/uwp/Diagram/Rulers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Rulers in UWP Diagram control | Syncfusion®
-description: Learn here all about Rulers support in the Syncfusion® UWP Diagram (SfDiagram) control and more.    
+description: Learn here all about Rulers support and customization in the Syncfusion® UWP Diagram (SfDiagram) control and more.    
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Rulers.md
+++ b/uwp/Diagram/Rulers.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Rulers in UWP Diagram control | Syncfusion®
-description: Learn here all about Rulers support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Rulers support in the Syncfusion® UWP Diagram (SfDiagram) control and more.    
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Serialization.md
+++ b/uwp/Diagram/Serialization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Serialization in UWP Diagram control | Syncfusion®
-description: Learn here all about Serialization support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Serialization support in the Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Serialization.md
+++ b/uwp/Diagram/Serialization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Serialization in UWP Diagram control | Syncfusion
-description: Learn here all about Serialization support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Serialization in UWP Diagram control | Syncfusion®
+description: Learn here all about Serialization support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Serialization.md
+++ b/uwp/Diagram/Serialization.md
@@ -9,7 +9,7 @@ documentation: ug
 
 # Serialization in UWP Diagram (SfDiagram)
 
-Serialization is the process of saving and loading the Essential Diagram for state persistence of the SfDiagram.
+Serialization is the process of saving and loading the Essential® Diagram for state persistence of the SfDiagram.
 
 In SfDiagram, DataContractSerializer is used for Serialization. The functionalities in DataContractSerializer are applicable to the SfDiagram Serialization. It supports saving the SfDiagram to stream. The SfDiagram gets saved with all its properties. On loading, it gets loaded in the current view with all its Nodes and Connectors. As a result, this feature enables you to save the SfDiagram for future use. You can continue working on the SfDiagram by loading the appropriate stream.
 

--- a/uwp/Diagram/Shapes.md
+++ b/uwp/Diagram/Shapes.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Shapes in UWP Diagram control | Syncfusion
-description: Learn here all about Shapes feature in Syncfusion Universal Windows Platform (UWP) Diagram (SfDiagram) control and more.
+title: Shapes in UWP Diagram control | Syncfusion®
+description: Learn here all about Shapes feature in Syncfusion® Universal Windows Platform (UWP) Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Stencil.md
+++ b/uwp/Diagram/Stencil.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Stencil in UWP Diagram control | Syncfusion
-description: Learn here all about Stencil support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Stencil in UWP Diagram control | Syncfusion®
+description: Learn here all about Stencil support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Stencil.md
+++ b/uwp/Diagram/Stencil.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Stencil in UWP Diagram control | Syncfusion®
-description: Learn here all about Stencil support in the Syncfusion® UWP Diagram (SfDiagram) control and more.    
+description: Learn here all about Stencil support in the Syncfusion® UWP Diagram (SfDiagram) control and much more.    
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Stencil.md
+++ b/uwp/Diagram/Stencil.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Stencil in UWP Diagram control | Syncfusion®
-description: Learn here all about Stencil support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Stencil support in the Syncfusion® UWP Diagram (SfDiagram) control and more.    
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Tools.md
+++ b/uwp/Diagram/Tools.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Tools in UWP Diagram control | Syncfusion
-description: Learn here all about Tools support in Syncfusion UWP Diagram (SfDiagram) control and more.
+title: Tools in UWP Diagram control | Syncfusion®
+description: Learn here all about Tools support in Syncfusion® UWP Diagram (SfDiagram) control and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Tools.md
+++ b/uwp/Diagram/Tools.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tools in UWP Diagram control | Syncfusion®
-description: Learn here all about Tools support in Syncfusion® UWP Diagram (SfDiagram) control and more.
+description: Learn here all about Tools support in the Syncfusion® UWP Diagram (SfDiagram) control and more.      
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Tools.md
+++ b/uwp/Diagram/Tools.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tools in UWP Diagram control | Syncfusion®
-description: Learn here all about Tools support in the Syncfusion® UWP Diagram (SfDiagram) control and more.      
+description: Learn here all about Tools support in the Syncfusion® UWP Diagram (SfDiagram) control and much more.      
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Virtualization.md
+++ b/uwp/Diagram/Virtualization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Virtualization in UWP Diagram control | Syncfusion®
-description: Learn here all about Virtualization support in Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
+description: Learn here all about Virtualization support in the Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
 platform: uwp
 control: SfDiagram
 documentation: ug

--- a/uwp/Diagram/Virtualization.md
+++ b/uwp/Diagram/Virtualization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Virtualization in UWP Diagram control | Syncfusion
-description: Learn here all about Virtualization support in Syncfusion UWP Diagram (SfDiagram) control, its elements and more.
+title: Virtualization in UWP Diagram control | Syncfusion®
+description: Learn here all about Virtualization support in Syncfusion® UWP Diagram (SfDiagram) control, its elements and more.
 platform: uwp
 control: SfDiagram
 documentation: ug


### PR DESCRIPTION
## Description ##
Added trademark symbols for these terms in Diagram Documentation
- Syncfusion®
- Essential®
- Essential Studio®
- **Add the "the" word before "Syncfusion®" to meet the description length requirements**
- **Highlight code syntax errors are fixed in this PR:** https://github.com/syncfusion-content/uwp-docs/pull/709