### PR TITLE
UG-940787 Included the Registered Trademark Symbol in Tools UWP UG Document

### DIFF
--- a/uwp/Accordion/Appearence-and-Styling.md
+++ b/uwp/Accordion/Appearence-and-Styling.md
@@ -2,7 +2,7 @@
 layout: post
 title: Appearance and Styling in UWP Accordion control | Syncfusion®
 description: Learn here all about Appearance and Styling support in Syncfusion® UWP Accordion (SfAccordion) control and more.
-platform: UWP
+platform: uwp
 control: SfAccordion
 documentation: ug
 

--- a/uwp/Accordion/Appearence-and-Styling.md
+++ b/uwp/Accordion/Appearence-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP Accordion control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP Accordion (SfAccordion) control and more.
+title: Appearance and Styling in UWP Accordion control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP Accordion (SfAccordion) control and more.
 platform: UWP
 control: SfAccordion
 documentation: ug

--- a/uwp/Accordion/Getting-Started.md
+++ b/uwp/Accordion/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Accordion control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Accordion (SfAccordion) control, its elements and more.
+title: Getting Started with UWP Accordion control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Accordion (SfAccordion) control, its elements and more.
 platform: uwp
 control: SfAccordion
 documentation: ug

--- a/uwp/Accordion/Overview.md
+++ b/uwp/Accordion/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Accordion control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Accordion (SfAccordion) control, its elements and more.
+title: About UWP Accordion control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Accordion (SfAccordion) control, its elements and more.
 platform: uwp
 control: SfAccordion
 documentation: ug

--- a/uwp/Accordion/Populating-Items.md
+++ b/uwp/Accordion/Populating-Items.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Populating Items in UWP Accordion control | Syncfusion
-description: Learn here all about Populating Items support in Syncfusion UWP Accordion (SfAccordion) control and more.
+title: Populating Items in UWP Accordion control | Syncfusion®
+description: Learn here all about Populating Items support in Syncfusion® UWP Accordion (SfAccordion) control and more.
 platform: uwp
 control: SfAccordion
 documentation: ug

--- a/uwp/Accordion/Selecting-Items.md
+++ b/uwp/Accordion/Selecting-Items.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Selecting Items in UWP Accordion control | Syncfusion
-description: Learn here all about Selecting Items support in Syncfusion UWP Accordion (SfAccordion) control and more.
+title: Selecting Items in UWP Accordion control | Syncfusion®
+description: Learn here all about Selecting Items support in Syncfusion® UWP Accordion (SfAccordion) control and more.
 platform: uwp
 control: SfAccordion
 documentation: ug

--- a/uwp/Accordion/Selection-Mode.md
+++ b/uwp/Accordion/Selection-Mode.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Selection Mode in UWP Accordion control | Syncfusion
-description: Learn here all about Selection Mode support in Syncfusion UWP Accordion (SfAccordion) control and more.
+title: Selection Mode in UWP Accordion control | Syncfusion®
+description: Learn here all about Selection Mode support in Syncfusion® UWP Accordion (SfAccordion) control and more.
 platform: uwp
 control: SfAccordion
 documentation: ug

--- a/uwp/Calculator/Appearance-and-Styling.md
+++ b/uwp/Calculator/Appearance-and-Styling.md
@@ -2,7 +2,7 @@
 layout: post
 title: Appearence and Styling in UWP Calculator control | Syncfusion®
 description: Learn here all about Appearence and Styling in Syncfusion® UWP Calculator (SfCalculator) control, its elements and more.
-platform: UWP
+platform: uwp
 control: SfCalculator
 documentation: ug
 ---

--- a/uwp/Calculator/Appearance-and-Styling.md
+++ b/uwp/Calculator/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearence and Styling in UWP Calculator control | Syncfusion
-description: Learn here all about Appearence and Styling in Syncfusion UWP Calculator (SfCalculator) control, its elements and more.
+title: Appearence and Styling in UWP Calculator control | Syncfusion®
+description: Learn here all about Appearence and Styling in Syncfusion® UWP Calculator (SfCalculator) control, its elements and more.
 platform: UWP
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Error-Message.md
+++ b/uwp/Calculator/Error-Message.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Error Message in UWP Calculator control | Syncfusion
-description: Learn here all about Error Message support in Syncfusion UWP Calculator (SfCalculator) control and more.
+title: Error Message in UWP Calculator control | Syncfusion®
+description: Learn here all about Error Message support in Syncfusion® UWP Calculator (SfCalculator) control and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Getting-Started.md
+++ b/uwp/Calculator/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Calculator control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Calculator (SfCalculator) control, its elements and more.
+title: Getting Started with UWP Calculator control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Calculator (SfCalculator) control, its elements and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Memory.md
+++ b/uwp/Calculator/Memory.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Memory in UWP Calculator control | Syncfusion®
-description: Learn here all about Memory support in Syncfusion® UWP Calculator (SfCalculator) control and more.
+description: Learn here all about Memory support in Syncfusion UWP Calculator (SfCalculator) control and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Memory.md
+++ b/uwp/Calculator/Memory.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Memory in UWP Calculator control | Syncfusion
-description: Learn here all about Memory support in Syncfusion UWP Calculator (SfCalculator) control and more.
+title: Memory in UWP Calculator control | Syncfusion®
+description: Learn here all about Memory support in Syncfusion® UWP Calculator (SfCalculator) control and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Memory.md
+++ b/uwp/Calculator/Memory.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Memory in UWP Calculator control | Syncfusion®
-description: Learn here all about Memory support in Syncfusion UWP Calculator (SfCalculator) control and more.
+description: Discover Memory support in Syncfusion® UWP Calculator (SfCalculator) control, including key features, usage, and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Other-utility-functions.md
+++ b/uwp/Calculator/Other-utility-functions.md
@@ -2,7 +2,7 @@
 layout: post
 title: Utilities in UWP Calculator control | Syncfusion®
 description: Learn here all about Utilities support in Syncfusion® UWP Calculator (SfCalculator) control and more.
-platform: UWP
+platform: uwp
 control: SfCalculator
 documentation: ug
 ---

--- a/uwp/Calculator/Other-utility-functions.md
+++ b/uwp/Calculator/Other-utility-functions.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Utilities in UWP Calculator control | Syncfusion
-description: Learn here all about Utilities support in Syncfusion UWP Calculator (SfCalculator) control and more.
+title: Utilities in UWP Calculator control | Syncfusion®
+description: Learn here all about Utilities support in Syncfusion® UWP Calculator (SfCalculator) control and more.
 platform: UWP
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Overview.md
+++ b/uwp/Calculator/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Calculator control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Calculator (SfCalculator) control, its elements and more.
+title: About UWP Calculator control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Calculator (SfCalculator) control, its elements and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Value.md
+++ b/uwp/Calculator/Value.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Value in UWP Calculator control | Syncfusion®
-description: Learn here all about Value support in Syncfusion UWP Calculator (SfCalculator) control and more.
+description: Explore Value support in Syncfusion® UWP Calculator (SfCalculator) control, including key features, usage, and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Value.md
+++ b/uwp/Calculator/Value.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Value in UWP Calculator control | Syncfusion®
-description: Learn here all about Value support in Syncfusion® UWP Calculator (SfCalculator) control and more.
+description: Learn here all about Value support in Syncfusion UWP Calculator (SfCalculator) control and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Calculator/Value.md
+++ b/uwp/Calculator/Value.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Value in UWP Calculator control | Syncfusion
-description: Learn here all about Value support in Syncfusion UWP Calculator (SfCalculator) control and more.
+title: Value in UWP Calculator control | Syncfusion®
+description: Learn here all about Value support in Syncfusion® UWP Calculator (SfCalculator) control and more.
 platform: uwp
 control: SfCalculator
 documentation: ug

--- a/uwp/Color-Palette/Dealing-With-SelectedColor.md
+++ b/uwp/Color-Palette/Dealing-With-SelectedColor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Dealing with SelectedColor in UWP Color Palette control | Syncfusion
-description: Learn here all about Dealing with SelectedColor support in Syncfusion UWP Color Palette (SfColorPalette) control and more.
+title: Dealing with SelectedColor in UWP Color Palette control | Syncfusion®
+description: Learn here all about Dealing with SelectedColor support in Syncfusion® UWP Color Palette (SfColorPalette) control and more.
 platform: uwp
 control: SfColorPalette
 documentation: ug

--- a/uwp/Color-Palette/Getting-Started.md
+++ b/uwp/Color-Palette/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Color Palette control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Color Palette (SfColorPalette) control, its elements and more.
+title: Getting Started with UWP Color Palette control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Color Palette (SfColorPalette) control, its elements and more.
 platform: uwp
 control: SfColorPalette
 documentation: ug

--- a/uwp/Color-Palette/Overview.md
+++ b/uwp/Color-Palette/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Color Palette control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Color Palette (SfColorPalette) control, its elements and more.
+title: About UWP Color Palette control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Color Palette (SfColorPalette) control, its elements and more.
 platform: uwp
 control: SfColorPalette
 documentation: ug

--- a/uwp/Color-Palette/Swatches-and-Colors.md
+++ b/uwp/Color-Palette/Swatches-and-Colors.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Navigation in UWP Color Palette control | Syncfusion
-description: Learn here all about Navigation support in Syncfusion UWP Color Palette (SfColorPalette) control and more.
+title: Navigation in UWP Color Palette control | Syncfusion®
+description: Learn here all about Navigation support in Syncfusion® UWP Color Palette (SfColorPalette) control and more.
 platform: uwp
 control: SfColorPalette
 documentation: ug

--- a/uwp/Color-Picker/Adjusting-Color.md
+++ b/uwp/Color-Picker/Adjusting-Color.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Adjusting Color Values in UWP Color Picker control | Syncfusion
-description: Learn here all about Adjusting Color Values support in Syncfusion UWP Color Picker (SfColorPicker) control and more.
+title: Adjusting Color Values in UWP Color Picker control | Syncfusion®
+description: Learn here all about Adjusting Color Values support in Syncfusion® UWP Color Picker (SfColorPicker) control and more.
 platform: uwp
 control: SfColorPicker
 documentation: ug

--- a/uwp/Color-Picker/Getting-Started.md
+++ b/uwp/Color-Picker/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Color Picker control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Color Picker (SfColorPicker) control, its elements and more.
+title: Getting Started with UWP Color Picker control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Color Picker (SfColorPicker) control, its elements and more.
 platform: uwp
 control: SfColorPicker
 documentation: ug

--- a/uwp/Color-Picker/Overview.md
+++ b/uwp/Color-Picker/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Color Picker control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Color Picker (SfColorPicker) control, its elements and more.
+title: About UWP Color Picker control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Color Picker (SfColorPicker) control, its elements and more.
 platform: uwp
 control: SfColorPicker
 documentation: ug

--- a/uwp/Color-Picker/Selecting-Color.md
+++ b/uwp/Color-Picker/Selecting-Color.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Selecting Color in UWP Color Picker control | Syncfusion
-description: Learn here all about Selecting Color support in Syncfusion UWP Color Picker (SfColorPicker) control and more.
+title: Selecting Color in UWP Color Picker control | Syncfusion®
+description: Learn here all about Selecting Color support in Syncfusion® UWP Color Picker (SfColorPicker) control and more.
 platform: uwp
 control: SfColorPicker
 documentation: ug

--- a/uwp/Combobox/Getting-Started.md
+++ b/uwp/Combobox/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP ComboBox control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP ComboBox (SfComboBox) control, its elements and more.
+title: Getting Started with UWP ComboBox control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP ComboBox (SfComboBox) control, its elements and more.
 platform: uwp
 control: SfComboBox  
 documentation: ug

--- a/uwp/Combobox/Overview.md
+++ b/uwp/Combobox/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP ComboBox control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP ComboBox (SfComboBox) control, its elements and more.
+title: About UWP ComboBox control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP ComboBox (SfComboBox) control, its elements and more.
 platform: uwp
 control: SfComboBox
 documentation: ug

--- a/uwp/DatePicker/Appearance-and-Styling.md
+++ b/uwp/DatePicker/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP DatePicker control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
+title: Appearance and Styling in UWP DatePicker control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP DatePicker (SfDatePicker) control and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/Customizing-DropDown.md
+++ b/uwp/DatePicker/Customizing-DropDown.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customizing DropDown in UWP DatePicker control | Syncfusion
-description: Learn here all about Customizing DropDown support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
+title: Customizing DropDown in UWP DatePicker control | Syncfusion®
+description: Learn here all about Customizing DropDown support in Syncfusion® UWP DatePicker (SfDatePicker) control and more.
 platform: uwp
 control:  SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/Footer.md
+++ b/uwp/DatePicker/Footer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Footer in UWP DatePicker control | Syncfusion®
-description: Learn here all about Footer support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
+description: Explore Footer support in Syncfusion® UWP DatePicker (SfDatePicker) control, including key features, customization options, and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/Footer.md
+++ b/uwp/DatePicker/Footer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Footer in UWP DatePicker control | Syncfusion
-description: Learn here all about Footer support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
+title: Footer in UWP DatePicker control | Syncfusion®
+description: Learn here all about Footer support in Syncfusion® UWP DatePicker (SfDatePicker) control and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/Footer.md
+++ b/uwp/DatePicker/Footer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Footer in UWP DatePicker control | Syncfusion®
-description: Learn here all about Footer support in Syncfusion® UWP DatePicker (SfDatePicker) control and more.
+description: Learn here all about Footer support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/Formatting.md
+++ b/uwp/DatePicker/Formatting.md
@@ -15,7 +15,7 @@ The SfDatePicker control allows the user to format the display text in various w
 
 The FormatString property determines the format specifier by which the display text has to be formatted.
 
-The following code sample shows how to create a date picker with a [month day pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.monthdaypattern(v=vs.71).aspx): 
+The following code sample shows how to create a date picker with a [month day pattern](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.datetimeformatinfo.monthdaypattern?view=net-9.0&redirectedfrom=MSDN#System_Globalization_DateTimeFormatInfo_MonthDayPattern): 
 
 {% tabs %}
 
@@ -96,4 +96,4 @@ sfdatePicker.SelectorFormatString = "M"
 ![Features_img2](Features_images/Features_img2.png)
 
 
-N> A detailed explanation of standard date time formatting is available [here](http://msdn.microsoft.com/en-us/library/az4se3k1(v=vs.71).aspx). The result string produced by these format specifiers are influenced by the settings in the Regional Options control panel. Computers with different cultures or different date and time settings will generate different result strings.
+N> A detailed explanation of standard date time formatting is available [here](https://learn.microsoft.com/en-us/previous-versions/dotnet/netframework-1.1/az4se3k1(v=vs.71)?redirectedfrom=MSDN). The result string produced by these format specifiers are influenced by the settings in the Regional Options control panel. Computers with different cultures or different date and time settings will generate different result strings.

--- a/uwp/DatePicker/Formatting.md
+++ b/uwp/DatePicker/Formatting.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Formatting in UWP DatePicker control | Syncfusion
-description: Learn here all about Formatting support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
+title: Formatting in UWP DatePicker control | Syncfusion®
+description: Learn here all about Formatting support in Syncfusion® UWP DatePicker (SfDatePicker) control and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/Formatting.md
+++ b/uwp/DatePicker/Formatting.md
@@ -96,4 +96,4 @@ sfdatePicker.SelectorFormatString = "M"
 ![Features_img2](Features_images/Features_img2.png)
 
 
-N> A detailed explanation of standard date time formatting is available [here](https://learn.microsoft.com/en-us/previous-versions/dotnet/netframework-1.1/az4se3k1(v=vs.71)?redirectedfrom=MSDN). The result string produced by these format specifiers are influenced by the settings in the Regional Options control panel. Computers with different cultures or different date and time settings will generate different result strings.
+N> A detailed explanation of standard date time formatting is available [here](https://learn.microsoft.com/en-us/previous-versions/dotnet/netframework-1.1/az4se3k1(v=vs.71)). The result string produced by these format specifiers are influenced by the settings in the Regional Options control panel. Computers with different cultures or different date and time settings will generate different result strings.

--- a/uwp/DatePicker/Getting-Started.md
+++ b/uwp/DatePicker/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP DatePicker control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP DatePicker (SfDatePicker) control, its elements and more.
+title: Getting Started with UWP DatePicker control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP DatePicker (SfDatePicker) control, its elements and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/Overview.md
+++ b/uwp/DatePicker/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP DatePicker control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP DatePicker (SfDatePicker) control, its elements and more.
+title: About UWP DatePicker control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP DatePicker (SfDatePicker) control, its elements and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/SelectorItem-Customization.md
+++ b/uwp/DatePicker/SelectorItem-Customization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: SelectorItem Customization in UWP DatePicker control | Syncfusion
-description: Learn here all about SelectorItem Customization support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
+title: SelectorItem Customization in UWP DatePicker control | Syncfusion®
+description: Learn here all about SelectorItem Customization support in Syncfusion® UWP DatePicker (SfDatePicker) control and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/Setting-Null-Value.md
+++ b/uwp/DatePicker/Setting-Null-Value.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Setting Null Value in UWP DatePicker control | Syncfusion
-description: Learn here all about Setting Null Value support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
+title: Setting Null Value in UWP DatePicker control | Syncfusion®
+description: Learn here all about Setting Null Value support in Syncfusion® UWP DatePicker (SfDatePicker) control and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/DatePicker/SfDateSelector.md
+++ b/uwp/DatePicker/SfDateSelector.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: SfDateSelector in UWP DatePicker control | Syncfusion
-description: Learn here all about SfDateSelector support in Syncfusion UWP DatePicker (SfDatePicker) control and more.
+title: SfDateSelector in UWP DatePicker control | Syncfusion®
+description: Learn here all about SfDateSelector support in Syncfusion® UWP DatePicker (SfDatePicker) control and more.
 platform: uwp
 control: SfDatePicker
 documentation: ug

--- a/uwp/Docking/Auto-Hide-Window.md
+++ b/uwp/Docking/Auto-Hide-Window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Auto Hide Window in UWP Docking control | Syncfusion
-description: Learn here all about Auto Hide Window support in Syncfusion UWP Docking (SfDockingManager) control and more.
+title: Auto Hide Window in UWP Docking control | Syncfusion®
+description: Learn here all about Auto Hide Window support in Syncfusion® UWP Docking (SfDockingManager) control and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/Dealing-with-Windows.md
+++ b/uwp/Docking/Dealing-with-Windows.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Dealing with Windows in UWP Docking control | Syncfusion
-description: Learn here all about Dealing with Windows support in Syncfusion UWP Docking (SfDockingManager) control and more.
+title: Dealing with Windows in UWP Docking control | Syncfusion®
+description: Learn here all about Dealing with Windows support in Syncfusion® UWP Docking (SfDockingManager) control and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/Docking-Window.md
+++ b/uwp/Docking/Docking-Window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Docking Window in UWP Docking control | Syncfusion
-description: Learn here all about Docking Window support in Syncfusion UWP Docking (SfDockingManager) control and more.
+title: Docking Window in UWP Docking control | Syncfusion®
+description: Learn here all about Docking Window support in Syncfusion® UWP Docking (SfDockingManager) control and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/Document-Windows.md
+++ b/uwp/Docking/Document-Windows.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Document Window in UWP Docking control | Syncfusion
-description: Learn here all about Document Window support in Syncfusion UWP Docking (SfDockingManager) control and more.
+title: Document Window in UWP Docking control | Syncfusion®
+description: Learn here all about Document Window support in Syncfusion® UWP Docking (SfDockingManager) control and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/Floating-Window.md
+++ b/uwp/Docking/Floating-Window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Floating Window in UWP Docking control | Syncfusion
-description: Learn here all about Floating Window support in Syncfusion UWP Docking (SfDockingManager) control and more.
+title: Floating Window in UWP Docking control | Syncfusion®
+description: Learn here all about Floating Window support in Syncfusion® UWP Docking (SfDockingManager) control and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/Getting-Started.md
+++ b/uwp/Docking/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Docking control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Docking (SfDockingManager) control, its elements and more.
+title: Getting Started with UWP Docking control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Docking (SfDockingManager) control, its elements and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/Nested-DockingManager.md
+++ b/uwp/Docking/Nested-DockingManager.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Nested DockingManager in UWP Docking control | Syncfusion
-description: Learn here all about Nested DockingManager support in Syncfusion UWP Docking (SfDockingManager) control and more.
+title: Nested DockingManager in UWP Docking control | Syncfusion®
+description: Learn here all about Nested DockingManager support in Syncfusion® UWP Docking (SfDockingManager) control and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/Overview.md
+++ b/uwp/Docking/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Docking control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Docking (SfDockingManager) control, its elements and more.
+title: About UWP Docking control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Docking (SfDockingManager) control, its elements and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/State-Persistence.md
+++ b/uwp/Docking/State-Persistence.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: State Persistence in UWP Docking control | Syncfusion
-description: Learn here all about State Persistence support in Syncfusion UWP Docking (SfDockingManager) control and more.
+title: State Persistence in UWP Docking control | Syncfusion®
+description: Learn here all about State Persistence support in Syncfusion® UWP Docking (SfDockingManager) control and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Docking/Tabbed-Window.md
+++ b/uwp/Docking/Tabbed-Window.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Tabbed Window in UWP Docking control | Syncfusion
-description: Learn here all about Tabbed Window support in Syncfusion UWP Docking (SfDockingManager) control and more.
+title: Tabbed Window in UWP Docking control | Syncfusion®
+description: Learn here all about Tabbed Window support in Syncfusion® UWP Docking (SfDockingManager) control and more.
 platform: uwp
 control: SfDockingManager
 documentation: ug

--- a/uwp/Domain-UpDown/Appearance-and-Styling.md
+++ b/uwp/Domain-UpDown/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP Domain UpDown control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP Domain UpDown (SfDomainUpDown) control and more.
+title: Appearance and Styling in UWP Domain UpDown control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP Domain UpDown (SfDomainUpDown) control and more.
 platform: uwp
 control: SfDomainUpDown
 documentation: ug

--- a/uwp/Domain-UpDown/AutoReverse.md
+++ b/uwp/Domain-UpDown/AutoReverse.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Autoreverse in UWP Domain UpDown control | Syncfusion
-description: Learn here all about Autoreverse support in Syncfusion UWP Domain UpDown (SfDomainUpDown) control and more.
+title: Autoreverse in UWP Domain UpDown control | Syncfusion®
+description: Learn here all about Autoreverse support in Syncfusion® UWP Domain UpDown (SfDomainUpDown) control and more.
 platform: uwp
 control: SfDomainUpDown
 documentation: ug

--- a/uwp/Domain-UpDown/Gestures.md
+++ b/uwp/Domain-UpDown/Gestures.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Gestures in UWP Domain UpDown control | Syncfusion
-description: Learn here all about Gestures support in Syncfusion UWP Domain UpDown (SfDomainUpDown) control and more.
+title: Gestures in UWP Domain UpDown control | Syncfusion®
+description: Learn here all about Gestures support in Syncfusion® UWP Domain UpDown (SfDomainUpDown) control and more.
 platform: uwp
 control: SfDomainUpDown
 documentation: ug

--- a/uwp/Domain-UpDown/Getting-Started.md
+++ b/uwp/Domain-UpDown/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Domain UpDown control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Domain UpDown (SfDomainUpDown) control, its elements and more.
+title: Getting Started with UWP Domain UpDown control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Domain UpDown (SfDomainUpDown) control, its elements and more.
 platform: uwp
 control: SfDomainUpDown
 documentation: ug

--- a/uwp/Domain-UpDown/Overview.md
+++ b/uwp/Domain-UpDown/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Domain UpDown control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Domain UpDown (SfDomainUpDown) control, its elements and more.
+title: About UWP Domain UpDown control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Domain UpDown (SfDomainUpDown) control, its elements and more.
 platform: uwp
 control: SfDomainUpDown
 documentation: ug

--- a/uwp/Domain-UpDown/Populating-Data.md
+++ b/uwp/Domain-UpDown/Populating-Data.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Populating Data in UWP Domain UpDown control | Syncfusion
-description: Learn here all about Populating Data support in Syncfusion UWP Domain UpDown (SfDomainUpDown) control and more.
+title: Populating Data in UWP Domain UpDown control | Syncfusion®
+description: Learn here all about Populating Data support in Syncfusion® UWP Domain UpDown (SfDomainUpDown) control and more.
 platform: uwp
 control: SfDomainUpDown
 documentation: ug

--- a/uwp/Domain-UpDown/Spin-Button-Alignment.md
+++ b/uwp/Domain-UpDown/Spin-Button-Alignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Spin Button Alignment in UWP Domain UpDown control | Syncfusion
-description: Learn here all about Spin Button Alignment support in Syncfusion UWP Domain UpDown (SfDomainUpDown) control and more.
+title: Spin Button Alignment in UWP Domain UpDown control | Syncfusion®
+description: Learn here all about Spin Button Alignment support in Syncfusion® UWP Domain UpDown (SfDomainUpDown) control and more.
 platform: uwp
 control: SfDomainUpDown
 documentation: ug

--- a/uwp/DropDown-Button/Apperance-and-Styling.md
+++ b/uwp/DropDown-Button/Apperance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP DropDown Button control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP DropDown Button (SfDropDownButton) control and more.
+title: Appearance and Styling in UWP DropDown Button control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP DropDown Button (SfDropDownButton) control and more.
 platform: uwp
 control:  SfDropDownButton
 documentation: ug

--- a/uwp/DropDown-Button/Configuring-Content.md
+++ b/uwp/DropDown-Button/Configuring-Content.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Configuring Content in UWP DropDown Button control | Syncfusion
-description: Learn here all about Configuring Content support in Syncfusion UWP DropDown Button (SfDropDownButton) control and more.
+title: Configuring Content in UWP DropDown Button control | Syncfusion®
+description: Learn here all about Configuring Content support in Syncfusion® UWP DropDown Button (SfDropDownButton) control and more.
 platform: uwp
 control:  SfDropDownButton
 documentation: ug

--- a/uwp/DropDown-Button/Customizing-DropDown.md
+++ b/uwp/DropDown-Button/Customizing-DropDown.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customizing DropDown in UWP DropDown Button control | Syncfusion
-description: Learn here all about Customizing DropDown support in Syncfusion UWP DropDown Button (SfDropDownButton) control and more.
+title: Customizing DropDown in UWP DropDown Button control | Syncfusion®
+description: Learn here all about Customizing DropDown support in Syncfusion® UWP DropDown Button (SfDropDownButton) control and more.
 platform: uwp
 control:  SfDropDownButton
 documentation: ug

--- a/uwp/DropDown-Button/Getting-Started.md
+++ b/uwp/DropDown-Button/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP DropDown Button control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP DropDown Button (SfDropDownButton) control, its elements and more.
+title: Getting Started with UWP DropDown Button control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP DropDown Button (SfDropDownButton) control, its elements and more.
 
 platform: uwp
 control:  SfDropDownButton

--- a/uwp/DropDown-Button/Overview.md
+++ b/uwp/DropDown-Button/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP DropDown Button control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP DropDown Button (SfDropDownButton) control, its elements and more.
+title: About UWP DropDown Button control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP DropDown Button (SfDropDownButton) control, its elements and more.
 platform: uwp
 control:  SfDropDownButton
 documentation: ug

--- a/uwp/Hub-Tile/HubTileBase.md
+++ b/uwp/Hub-Tile/HubTileBase.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: HubTileBase in UWP Hub Tile control | Syncfusion
-description: Learn here all about HubTileBase support in Syncfusion UWP Hub Tile (HubTiles) control and more.
+title: HubTileBase in UWP Hub Tile control | Syncfusion®
+description: Learn here all about HubTileBase support in Syncfusion® UWP Hub Tile (HubTiles) control and more.
 platform: uwp
 control: HubTileBase
 documentation: ug

--- a/uwp/Hub-Tile/SfHubTile.md
+++ b/uwp/Hub-Tile/SfHubTile.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: SfHubTile in UWP Hub Tile control | Syncfusion
-description: Learn here all about SfHubTile support in Syncfusion Universal Windows Platform (UWP) Hub Tile (HubTiles) control and more.
+title: SfHubTile in UWP Hub Tile control | Syncfusion®
+description: Learn here all about SfHubTile support in Syncfusion® Universal Windows Platform (UWP) Hub Tile (HubTiles) control and more.
 platform: uwp
 control: SfHubTile
 documentation: ug

--- a/uwp/Hub-Tile/SfMosaicTile.md
+++ b/uwp/Hub-Tile/SfMosaicTile.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: SfMosaicTile in UWP Hub Tile control | Syncfusion
-description: Learn here all about SfMosaicTile support in Syncfusion Universal Windows Platform (UWP) Hub Tile (HubTiles) control and more.
+title: SfMosaicTile in UWP Hub Tile control | Syncfusion®
+description: Learn here all about SfMosaicTile support in Syncfusion® Universal Windows Platform (UWP) Hub Tile (HubTiles) control and more.
 platform: uwp
 control: SfMosaicTile
 documentation: ug

--- a/uwp/Hub-Tile/SfSplitMosaicTile.md
+++ b/uwp/Hub-Tile/SfSplitMosaicTile.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: SfSplitMosaicTile in UWP Hub Tile control | Syncfusion
-description: Learn here all about SfSplitMosaicTile support in Syncfusion UWP Hub Tile (HubTiles) control and more.
+title: SfSplitMosaicTile in UWP Hub Tile control | Syncfusion®
+description: Learn here all about SfSplitMosaicTile support in Syncfusion® UWP Hub Tile (HubTiles) control and more.
 platform: uwp
 control: SfSplitMosaicTile
 documentation: ug

--- a/uwp/Hub-Tile/SfpulsingTile.md
+++ b/uwp/Hub-Tile/SfpulsingTile.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: SfPulsingTile in UWP Hub Tile control | Syncfusion
-description: Learn here all about SfPulsingTile support in Syncfusion UWP Hub Tile (HubTiles) control, its elements, features, and more.
+title: SfPulsingTile in UWP Hub Tile control | Syncfusion®
+description: Learn here all about SfPulsingTile support in Syncfusion® UWP Hub Tile (HubTiles) control, its elements, features, and more.
 platform: uwp
 control: SfPulsingTile
 documentation: ug

--- a/uwp/Masked-TextBox/Appearance.md
+++ b/uwp/Masked-TextBox/Appearance.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance in UWP Masked TextBox control | Syncfusion
-description: Learn here all about Appearance support in Syncfusion UWP Masked TextBox (SfMaskedEdit) control and more.
+title: Appearance in UWP Masked TextBox control | Syncfusion®
+description: Learn here all about Appearance support in Syncfusion® UWP Masked TextBox (SfMaskedEdit) control and more.
 platform: uwp
 control: SfMaskedEdit
 documentation: ug

--- a/uwp/Masked-TextBox/Getting-Started.md
+++ b/uwp/Masked-TextBox/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Masked TextBox control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Masked TextBox (SfMaskedEdit) control, its elements and more.
+title: Getting Started with UWP Masked TextBox control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Masked TextBox (SfMaskedEdit) control, its elements and more.
 platform: uwp
 control: SfMaskedEdit
 documentation: ug

--- a/uwp/Masked-TextBox/Mask-Options.md
+++ b/uwp/Masked-TextBox/Mask-Options.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Mask Options in UWP Masked TextBox control | Syncfusion
-description: Learn here all about Mask Options support in Syncfusion UWP Masked TextBox (SfMaskedEdit) control and more.
+title: Mask Options in UWP Masked TextBox control | Syncfusion®
+description: Learn here all about Mask Options support in Syncfusion® UWP Masked TextBox (SfMaskedEdit) control and more.
 platform: uwp
 control: SfMaskedEdit
 documentation: ug

--- a/uwp/Masked-TextBox/Overview.md
+++ b/uwp/Masked-TextBox/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Masked TextBox control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Masked TextBox (SfMaskedEdit) control, its elements and more.
+title: About UWP Masked TextBox control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Masked TextBox (SfMaskedEdit) control, its elements and more.
 platform: uwp
 control: SfMaskedEdit
 documentation: ug

--- a/uwp/Masked-TextBox/PromptChar-in-Mask.md
+++ b/uwp/Masked-TextBox/PromptChar-in-Mask.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: PromptChar in Mask in UWP Masked TextBox control | Syncfusion
-description: Learn here all about PromptChar in Mask support in Syncfusion UWP Masked TextBox (SfMaskedEdit) control and more.
+title: PromptChar in Mask in UWP Masked TextBox control | Syncfusion®
+description: Learn here all about PromptChar in Mask support in Syncfusion® UWP Masked TextBox (SfMaskedEdit) control and more.
 platform: uwp
 control: SfMaskedEdit
 documentation: ug

--- a/uwp/Masked-TextBox/Validation.md
+++ b/uwp/Masked-TextBox/Validation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Validation in UWP Masked TextBox control | Syncfusion
-description: Learn here all about Validation support in Syncfusion UWP Masked TextBox (SfMaskedEdit) control and more.
+title: Validation in UWP Masked TextBox control | Syncfusion®
+description: Learn here all about Validation support in Syncfusion® UWP Masked TextBox (SfMaskedEdit) control and more.
 platform: uwp
 control: SfMaskedEdit
 documentation: ug

--- a/uwp/Masked-TextBox/ValueMode.md
+++ b/uwp/Masked-TextBox/ValueMode.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Value Mode in UWP Masked TextBox control | Syncfusion
-description: Learn here all about Value Mode support in Syncfusion UWP Masked TextBox (SfMaskedEdit) control and more.
+title: Value Mode in UWP Masked TextBox control | Syncfusion®
+description: Learn here all about Value Mode support in Syncfusion® UWP Masked TextBox (SfMaskedEdit) control and more.
 platform: uwp
 control: SfMaskedEdit
 documentation: ug 

--- a/uwp/Masked-TextBox/Working-with-SfMaskedEdit.md
+++ b/uwp/Masked-TextBox/Working-with-SfMaskedEdit.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Working with SfMaskedEdit in UWP Masked TextBox control | Syncfusion
-description: Learn here all about Working with SfMaskedEdit support in Syncfusion UWP Masked TextBox (SfMaskedEdit) control and more.
+title: Working with SfMaskedEdit in UWP Masked TextBox control | Syncfusion®
+description: Learn here all about Working with SfMaskedEdit support in Syncfusion® UWP Masked TextBox (SfMaskedEdit) control and more.
 platform: uwp
 control: SfMaskedEdit
 documentation: ug

--- a/uwp/Menu/Animation-Support.md
+++ b/uwp/Menu/Animation-Support.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Animation Support in UWP Menu control | Syncfusion
-description: Learn here all about Animation Support support in Syncfusion UWP Menu (SfMenu) control and more.
+title: Animation Support in UWP Menu control | Syncfusion®
+description: Learn here all about Animation Support support in Syncfusion® UWP Menu (SfMenu) control and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Menu/Check-Box-and-Radio-Button.md
+++ b/uwp/Menu/Check-Box-and-Radio-Button.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: CheckBox and RadioButton in UWP Menu control | Syncfusion
-description: Learn here all about CheckBox and RadioButton support in Syncfusion UWP Menu (SfMenu) control and more.
+title: CheckBox and RadioButton in UWP Menu control | Syncfusion®
+description: Learn here all about CheckBox and RadioButton support in Syncfusion® UWP Menu (SfMenu) control and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Menu/Expand-Modes.md
+++ b/uwp/Menu/Expand-Modes.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Expand Modes in UWP Menu control | Syncfusion
-description: Learn here all about Expand Modes support in Syncfusion UWP Menu (SfMenu) control and more.
+title: Expand Modes in UWP Menu control | Syncfusion®
+description: Learn here all about Expand Modes support in Syncfusion® UWP Menu (SfMenu) control and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Menu/Getting-Started.md
+++ b/uwp/Menu/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Menu control | Syncfusion
-description: Learn here about getting started with Syncfusion Essential Studio UWP Menu (SfMenu) control, its elements and more.
+title: Getting Started with UWP Menu control | Syncfusion®
+description: Learn here about getting started with Syncfusion® Essential Studio® UWP Menu (SfMenu) control, its elements and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Menu/Icon-Support.md
+++ b/uwp/Menu/Icon-Support.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Set Icons in UWP Menu control | Syncfusion
-description: Learn here all about Set Icons support in Syncfusion UWP Menu (SfMenu) control and more.
+title: Set Icons in UWP Menu control | Syncfusion®
+description: Learn here all about Set Icons support in Syncfusion® UWP Menu (SfMenu) control and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Menu/Input-Gesture-Text.md
+++ b/uwp/Menu/Input-Gesture-Text.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Input Gesture Text in UWP Menu control | Syncfusion
-description: Learn here all about Input Gesture Text support in Syncfusion UWP Menu (SfMenu) control and more.
+title: Input Gesture Text in UWP Menu control | Syncfusion®
+description: Learn here all about Input Gesture Text support in Syncfusion® UWP Menu (SfMenu) control and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Menu/Orientation.md
+++ b/uwp/Menu/Orientation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Orientation in UWP Menu control | Syncfusion
-description: Learn here all about Orientation support in Syncfusion UWP Menu (SfMenu) control and more.
+title: Orientation in UWP Menu control | Syncfusion®
+description: Learn here all about Orientation support in Syncfusion® UWP Menu (SfMenu) control and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Menu/Overview.md
+++ b/uwp/Menu/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Menu control | Syncfusion
-description: Learn here all about introduction of Syncfusion Essential Studio UWP Menu (SfMenu) control, its elements and more.
+title: About UWP Menu control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® Essential Studio® UWP Menu (SfMenu) control, its elements and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Menu/Populating-Items.md
+++ b/uwp/Menu/Populating-Items.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Populating Items in UWP Menu control | Syncfusion
-description: Learn here all about Populating Items support in Syncfusion UWP Menu (SfMenu) control and more.
+title: Populating Items in UWP Menu control | Syncfusion®
+description: Learn here all about Populating Items support in Syncfusion® UWP Menu (SfMenu) control and more.
 platform: UWP
 control: SfMenu
 documentation: ug

--- a/uwp/Navigation-Pane/Customizing-GroupBar.md
+++ b/uwp/Navigation-Pane/Customizing-GroupBar.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customizing GroupBar in UWP Navigation Pane control | Syncfusion
-description: Learn here all about Customizing GroupBar support in Syncfusion UWP Navigation Pane (SfGroupBar) control and more.
+title: Customizing GroupBar in UWP Navigation Pane control | Syncfusion®
+description: Learn here all about Customizing GroupBar support in Syncfusion® UWP Navigation Pane (SfGroupBar) control and more.
 platform: UWP
 control: SfGroupBar
 documentation: ug

--- a/uwp/Progress-Bar/Animating-Custom-Objects.md
+++ b/uwp/Progress-Bar/Animating-Custom-Objects.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Animating Custom Objects in UWP Progress Bar control | Syncfusion
-description: Learn here all about Animating Custom Objects support in Syncfusion UWP Progress Bar (SfProgressBar) control and more.
+title: Animating Custom Objects in UWP Progress Bar control | Syncfusion®
+description: Learn here all about Animating Custom Objects support in Syncfusion® UWP Progress Bar (SfProgressBar) control and more.
 platform: UWP
 control: SfProgressBar
 documentation: ug

--- a/uwp/Progress-Bar/Appearance-and-Styling.md
+++ b/uwp/Progress-Bar/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP Progress Bar control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP Progress Bar (SfProgressBar) control and more.
+title: Appearance and Styling in UWP Progress Bar control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP Progress Bar (SfProgressBar) control and more.
 platform: UWP
 control: SfProgressBar
 documentation: ug

--- a/uwp/Progress-Bar/Dealing-with-Value.md
+++ b/uwp/Progress-Bar/Dealing-with-Value.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Dealing with Value in UWP Progress Bar control | Syncfusion
-description: Learn here all about Dealing with Value support in Syncfusion UWP Progress Bar (SfProgressBar) control and more.
+title: Dealing with Value in UWP Progress Bar control | Syncfusion®
+description: Learn here all about Dealing with Value support in Syncfusion® UWP Progress Bar (SfProgressBar) control and more.
 platform: UWP
 control: SfProgressBar
 documentation: ug

--- a/uwp/Progress-Bar/Displaying-Progress-Text.md
+++ b/uwp/Progress-Bar/Displaying-Progress-Text.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Displaying Progress Text in UWP Progress Bar control | Syncfusion
-description: Learn here all about Displaying Progress Text support in Syncfusion UWP Progress Bar (SfProgressBar) control and more.
+title: Displaying Progress Text in UWP Progress Bar control | Syncfusion®
+description: Learn here all about Displaying Progress Text support in Syncfusion® UWP Progress Bar (SfProgressBar) control and more.
 platform: UWP
 control: SfProgressBar
 documentation: ug

--- a/uwp/Progress-Bar/Getting-Started.md
+++ b/uwp/Progress-Bar/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Progress Bar control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Progress Bar (SfProgressBar) control, its elements and more.
+title: Getting Started with UWP Progress Bar control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Progress Bar (SfProgressBar) control, its elements and more.
 platform: UWP
 control: SfProgressBar
 documentation: ug

--- a/uwp/Progress-Bar/Overview.md
+++ b/uwp/Progress-Bar/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Progress Bar control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Progress Bar (SfProgressBar) control, its elements and more.
+title: About UWP Progress Bar control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Progress Bar (SfProgressBar) control, its elements and more.
 platform: UWP
 control: SfProgressBar
 documentation: ug

--- a/uwp/Progress-Bar/Progress-Animations.md
+++ b/uwp/Progress-Bar/Progress-Animations.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Progress Animations in UWP Progress Bar control | Syncfusion
-description: Learn here all about Progress Animations support in Syncfusion UWP Progress Bar (SfProgressBar) control and more.
+title: Progress Animations in UWP Progress Bar control | Syncfusion®
+description: Learn here all about Progress Animations support in Syncfusion® UWP Progress Bar (SfProgressBar) control and more.
 platform: UWP
 control: SfProgressBar
 documentation: ug

--- a/uwp/Radial-Slider/Appearance-and-Styling.md
+++ b/uwp/Radial-Slider/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP Radial Slider control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Appearance and Styling in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Content-Template.md
+++ b/uwp/Radial-Slider/Content-Template.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Content Template in UWP Radial Slider control | Syncfusion
-description: Learn here all about Content Template support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Content Template in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Content Template support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Content.md
+++ b/uwp/Radial-Slider/Content.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Content in UWP Radial Slider control | Syncfusion
-description: Learn here all about Content support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Content in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Content support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/End-Angle.md
+++ b/uwp/Radial-Slider/End-Angle.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: End Angle in UWP Radial Slider control | Syncfusion
-description: Learn here all about End Angle support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: End Angle in UWP Radial Slider control | Syncfusion®
+description: Learn here all about End Angle support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Getting-Started.md
+++ b/uwp/Radial-Slider/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Radial Slider control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Radial Slider (SfRadialSlider) control, its elements and more.
+title: Getting Started with UWP Radial Slider control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Radial Slider (SfRadialSlider) control, its elements and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Intermediate-Value.md
+++ b/uwp/Radial-Slider/Intermediate-Value.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Intermediate Value in UWP Radial Slider control | Syncfusion
-description: Learn here all about Intermediate Value support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Intermediate Value in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Intermediate Value support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Labels.md
+++ b/uwp/Radial-Slider/Labels.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Labels in UWP Radial Slider control | Syncfusion
-description: Learn here all about Labels support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Labels in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Labels support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Maximum.md
+++ b/uwp/Radial-Slider/Maximum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: maximum in UWP Radial Slider control | Syncfusion
-description: Learn here all about maximum support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: maximum in UWP Radial Slider control | Syncfusion®
+description: Learn here all about maximum support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Minimum.md
+++ b/uwp/Radial-Slider/Minimum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Minimum in UWP Radial Slider control | Syncfusion
-description: Learn here all about Minimum support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Minimum in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Minimum support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Overview.md
+++ b/uwp/Radial-Slider/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Radial Slider control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Radial Slider (SfRadialSlider) control, its elements and more.
+title: About UWP Radial Slider control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Radial Slider (SfRadialSlider) control, its elements and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Small-Change.md
+++ b/uwp/Radial-Slider/Small-Change.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Small Change in UWP Radial Slider control | Syncfusion
-description: Learn here all about Small Change support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Small Change in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Small Change support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Start-Angle.md
+++ b/uwp/Radial-Slider/Start-Angle.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Start Angle in UWP Radial Slider control | Syncfusion
-description: Learn here all about Start Angle support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Start Angle in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Start Angle support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Ticks.md
+++ b/uwp/Radial-Slider/Ticks.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Ticks in UWP Radial Slider control | Syncfusion
-description: Learn here all about Ticks support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Ticks in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Ticks support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Radial-Slider/Value.md
+++ b/uwp/Radial-Slider/Value.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Value in UWP Radial Slider control | Syncfusion
-description: Learn here all about Value support in Syncfusion UWP Radial Slider (SfRadialSlider) control and more.
+title: Value in UWP Radial Slider control | Syncfusion®
+description: Learn here all about Value support in Syncfusion® UWP Radial Slider (SfRadialSlider) control and more.
 platform: uwp
 control: SfRadial Slider 
 documentation: ug

--- a/uwp/Spell-Checker/context-menu-suggestion.md
+++ b/uwp/Spell-Checker/context-menu-suggestion.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Context Menu Suggestion in UWP Spell Checker control | Syncfusion
-description: Learn here all about Context Menu Suggestion support in Syncfusion UWP Spell Checker (SfSpellChecker) control and more.
+title: Context Menu Suggestion in UWP Spell Checker control | Syncfusion®
+description: Learn here all about Context Menu Suggestion support in Syncfusion® UWP Spell Checker (SfSpellChecker) control and more.
 platform: UWP
 control: SfSpellChecker
 documentation: ug

--- a/uwp/Spell-Checker/custom-dictionary-support.md
+++ b/uwp/Spell-Checker/custom-dictionary-support.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Custom Dictionary in UWP Spell Checker control | Syncfusion
-description: Learn here all about Custom Dictionary support in Syncfusion UWP Spell Checker (SfSpellChecker) control and more.
+title: Custom Dictionary in UWP Spell Checker control | Syncfusion®
+description: Learn here all about Custom Dictionary support in Syncfusion® UWP Spell Checker (SfSpellChecker) control and more.
 platform: UWP
 control: SfSpellChecker
 documentation: ug

--- a/uwp/Spell-Checker/getting-started.md
+++ b/uwp/Spell-Checker/getting-started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Spell Checker control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Spell Checker (SfSpellChecker) control, its elements and more.
+title: Getting Started with UWP Spell Checker control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Spell Checker (SfSpellChecker) control, its elements and more.
 platform: UWP
 control: SfSpellChecker
 documentation: ug

--- a/uwp/Spell-Checker/localization.md
+++ b/uwp/Spell-Checker/localization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Localization in UWP Spell Checker control | Syncfusion
-description: Learn here all about Localization support in Syncfusion UWP Spell Checker (SfSpellChecker) control and more.
+title: Localization in UWP Spell Checker control | Syncfusion®
+description: Learn here all about Localization support in Syncfusion® UWP Spell Checker (SfSpellChecker) control and more.
 platform: UWP
 control: SfSpellChecker
 documentation: ug

--- a/uwp/Spell-Checker/overview.md
+++ b/uwp/Spell-Checker/overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Spell Checker control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Spell Checker (SfSpellChecker) control, its elements and more.
+title: About UWP Spell Checker control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Spell Checker (SfSpellChecker) control, its elements and more.
 platform: UWP
 control: SfSpellChecker
 documentation: ug

--- a/uwp/Spell-Checker/spell-checking-options.md
+++ b/uwp/Spell-Checker/spell-checking-options.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Spell Check in UWP Spell Checker control | Syncfusion
-description: Learn here all about Spell Check support in Syncfusion UWP Spell Checker (SfSpellChecker) control and more.
+title: Spell Check in UWP Spell Checker control | Syncfusion®
+description: Learn here all about Spell Check support in Syncfusion® UWP Spell Checker (SfSpellChecker) control and more.
 platform: UWP
 control: SfSpellChecker
 documentation: ug

--- a/uwp/Tab-Control/Appearance-and-Styling.md
+++ b/uwp/Tab-Control/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP Tab Control control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP Tab Control (SfTabControl) control and more.
+title: Appearance and Styling in UWP Tab Control control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP Tab Control (SfTabControl) control and more.
 platform: UWP
 control: SfTabControl
 documentation: ug

--- a/uwp/Tab-Control/Close-and-Scroll-button-functionalities.md
+++ b/uwp/Tab-Control/Close-and-Scroll-button-functionalities.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Close and Scroll button functionalities in UWP Tab Control control | Syncfusion
-description: Learn here all about Close and Scroll button functionalities support in Syncfusion UWP Tab Control (SfTabControl) control and more.
+title: Close and Scroll button functionalities in UWP Tab Control control | Syncfusion®
+description: Learn here all about Close and Scroll button functionalities support in Syncfusion® UWP Tab Control (SfTabControl) control and more.
 platform: uwp
 control: SfTabControl
 documentation: ug

--- a/uwp/Tab-Control/Dealing-with-Pinnable-Tabitems.md
+++ b/uwp/Tab-Control/Dealing-with-Pinnable-Tabitems.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Dealing with Pinnable Tabitems in UWP Tab Control control | Syncfusion
-description: Learn here all about Dealing with Pinnable Tabitems support in Syncfusion UWP Tab Control (SfTabControl) control and more.
+title: Dealing with Pinnable Tabitems in UWP Tab Control control | Syncfusion®
+description: Learn here all about Dealing with Pinnable Tabitems support in Syncfusion® UWP Tab Control (SfTabControl) control and more.
 platform: uwp
 control: SfTabControl
 documentation: ug

--- a/uwp/Tab-Control/Getting-Started.md
+++ b/uwp/Tab-Control/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Tab Control control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Tab Control (SfTabControl) control, its elements and more.
+title: Getting Started with UWP Tab Control control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Tab Control (SfTabControl) control, its elements and more.
 platform: uwp
 control: SfTabControl
 documentation: ug

--- a/uwp/Tab-Control/Overview.md
+++ b/uwp/Tab-Control/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Tab Control control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Tab Control (SfTabControl) control, its elements and more.
+title: About UWP Tab Control control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Tab Control (SfTabControl) control, its elements and more.
 platform: uwp
 control: SfTabControl
 documentation: ug

--- a/uwp/Tab-Control/Populating-Items.md
+++ b/uwp/Tab-Control/Populating-Items.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Populating Items in UWP Tab Control control | Syncfusion
-description: Learn here all about Populating Items support in Syncfusion UWP Tab Control (SfTabControl) control and more.
+title: Populating Items in UWP Tab Control control | Syncfusion®
+description: Learn here all about Populating Items support in Syncfusion® UWP Tab Control (SfTabControl) control and more.
 platform: uwp
 control: SfTabControl
 documentation: ug

--- a/uwp/Tab-Control/Selecting-Tabitems.md
+++ b/uwp/Tab-Control/Selecting-Tabitems.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Selecting Items in UWP Tab Control control | Syncfusion
-description: Learn here all about Selecting Items support in Syncfusion UWP Tab Control (SfTabControl) control and more.
+title: Selecting Items in UWP Tab Control control | Syncfusion®
+description: Learn here all about Selecting Items support in Syncfusion® UWP Tab Control (SfTabControl) control and more.
 platform: uwp
 control: SfTabControl
 documentation: ug

--- a/uwp/Tab-Control/Selection-Style.md
+++ b/uwp/Tab-Control/Selection-Style.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Selection Style in UWP Tab Control control | Syncfusion
-description: Learn here all about Selection Style support in Syncfusion UWP Tab Control (SfTabControl) control and more.
+title: Selection Style in UWP Tab Control control | Syncfusion®
+description: Learn here all about Selection Style support in Syncfusion® UWP Tab Control (SfTabControl) control and more.
 platform: uwp
 control: SfTabControl
 documentation: ug

--- a/uwp/Tab-Control/TabStripPlacement-and-menu.md
+++ b/uwp/Tab-Control/TabStripPlacement-and-menu.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: TabStripPlacement and Menu in UWP Tab Control control | Syncfusion
-description: Learn here all about TabStripPlacement and Menu support in Syncfusion UWP Tab Control (SfTabControl) control and more.
+title: TabStripPlacement and Menu in UWP Tab Control control | Syncfusion®
+description: Learn here all about TabStripPlacement and Menu support in Syncfusion® UWP Tab Control (SfTabControl) control and more.
 platform: uwp
 control: SfTabControl
 documentation: ug

--- a/uwp/Tile-View/Appearance-and-Styling.md
+++ b/uwp/Tile-View/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP Tile View control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP Tile View (SfTileView) control and more.
+title: Appearance and Styling in UWP Tile View control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP Tile View (SfTileView) control and more.
 platform: uwp
 control: SfTileView
 documentation: ug

--- a/uwp/Tile-View/Customizing-maximized-item.md
+++ b/uwp/Tile-View/Customizing-maximized-item.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customizing Maximized Item in UWP Tile View control | Syncfusion
-description: Learn here all about Customizing Maximized Item support in Syncfusion UWP Tile View (SfTileView) control and more.
+title: Customizing Maximized Item in UWP Tile View control | Syncfusion®
+description: Learn here all about Customizing Maximized Item support in Syncfusion® UWP Tile View (SfTileView) control and more.
 platform: uwp
 control: SfTileView
 documentation: ug

--- a/uwp/Tile-View/Dealing-with-item-state.md
+++ b/uwp/Tile-View/Dealing-with-item-state.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Dealing with State in UWP Tile View control | Syncfusion
-description: Learn here all about Dealing with State support in Syncfusion UWP Tile View (SfTileView) control and more.
+title: Dealing with State in UWP Tile View control | Syncfusion®
+description: Learn here all about Dealing with State support in Syncfusion® UWP Tile View (SfTileView) control and more.
 platform: uwp
 control: SfTileView
 documentation: ug

--- a/uwp/Tile-View/Getting-Started.md
+++ b/uwp/Tile-View/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Tile View control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Tile View (SfTileView) control, its elements and more.
+title: Getting Started with UWP Tile View control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Tile View (SfTileView) control, its elements and more.
 platform: uwp
 control: SfTileView
 documentation: ug

--- a/uwp/Tile-View/Overview.md
+++ b/uwp/Tile-View/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Tile View control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Tile View (SfTileView) control, its elements and more.
+title: About UWP Tile View control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Tile View (SfTileView) control, its elements and more.
 platform: uwp
 control: SfTileView
 documentation: ug

--- a/uwp/Tile-View/Populating-Items.md
+++ b/uwp/Tile-View/Populating-Items.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Populating Items in UWP Tile View control | Syncfusion
-description: Learn here all about Populating Items support in Syncfusion UWP Tile View (SfTileView) control and more.
+title: Populating Items in UWP Tile View control | Syncfusion®
+description: Learn here all about Populating Items support in Syncfusion® UWP Tile View (SfTileView) control and more.
 platform: uwp
 control: SfTileView
 documentation: ug

--- a/uwp/Tile-View/Re-ordering-and-orientation.md
+++ b/uwp/Tile-View/Re-ordering-and-orientation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Re-ordering and Orientation in UWP Tile View control | Syncfusion
-description: Learn here all about Re-ordering and Orientation support in Syncfusion UWP Tile View (SfTileView) control and more.
+title: Re-ordering and Orientation in UWP Tile View control | Syncfusion®
+description: Learn here all about Re-ordering and Orientation support in Syncfusion® UWP Tile View (SfTileView) control and more.
 platform: uwp
 control: SfTileView
 documentation: ug

--- a/uwp/Timepicker/Appearance-and-Styling.md
+++ b/uwp/Timepicker/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP TimePicker control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP TimePicker (SfTimePicker) control and more.
+title: Appearance and Styling in UWP TimePicker control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP TimePicker (SfTimePicker) control and more.
 platform: uwp
 control: SfTimePicker
 documentation: ug

--- a/uwp/Timepicker/Customizing-DropDown.md
+++ b/uwp/Timepicker/Customizing-DropDown.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Customizing DropDown in UWP TimePicker control | Syncfusion
-description: Learn here all about Customizing DropDown support in Syncfusion UWP TimePicker (SfTimePicker) control and more.
+title: Customizing DropDown in UWP TimePicker control | Syncfusion®
+description: Learn here all about Customizing DropDown support in Syncfusion® UWP TimePicker (SfTimePicker) control and more.
 platform: uwp
 control:  SfTimePicker
 documentation: ug

--- a/uwp/Timepicker/Footer.md
+++ b/uwp/Timepicker/Footer.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Footer in UWP TimePicker control | Syncfusion
-description: Learn here all about Footer support in Syncfusion UWP TimePicker (SfTimePicker) control and more.
+title: Footer in UWP TimePicker control | Syncfusion®
+description: Learn here all about Footer support in Syncfusion® UWP TimePicker (SfTimePicker) control and more.
 platform: uwp
 control: SfTimePicker
 documentation: ug

--- a/uwp/Timepicker/Formatting.md
+++ b/uwp/Timepicker/Formatting.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Formatting in UWP TimePicker control | Syncfusion
-description: Learn here all about Formatting support in Syncfusion UWP TimePicker (SfTimePicker) control and more.
+title: Formatting in UWP TimePicker control | Syncfusion®
+description: Learn here all about Formatting support in Syncfusion® UWP TimePicker (SfTimePicker) control and more.
 platform: uwp
 control: SfTimePicker
 documentation: ug

--- a/uwp/Timepicker/Getting-Started.md
+++ b/uwp/Timepicker/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP TimePicker control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP TimePicker (SfTimePicker) control, its elements and more.
+title: Getting Started with UWP TimePicker control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP TimePicker (SfTimePicker) control, its elements and more.
 platform: uwp
 control: SfTimePicker
 documentation: ug

--- a/uwp/Timepicker/Overview.md
+++ b/uwp/Timepicker/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP TimePicker control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP TimePicker (SfTimePicker) control, its elements and more.
+title: About UWP TimePicker control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP TimePicker (SfTimePicker) control, its elements and more.
 platform: uwp
 control: SfTimePicker
 documentation: ug

--- a/uwp/Timepicker/SelectorItem-Customization.md
+++ b/uwp/Timepicker/SelectorItem-Customization.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: SelectorItem Customization in UWP TimePicker control | Syncfusion
-description: Learn here all about SelectorItem Customization support in Syncfusion UWP TimePicker (SfTimePicker) control and more.
+title: SelectorItem Customization in UWP TimePicker control | Syncfusion®
+description: Learn here all about SelectorItem Customization support in Syncfusion® UWP TimePicker (SfTimePicker) control and more.
 platform: uwp
 control: SfTimePicker
 documentation: ug

--- a/uwp/Timepicker/Setting-Null-Value.md
+++ b/uwp/Timepicker/Setting-Null-Value.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Setting Null Value in UWP TimePicker control | Syncfusion
-description: Learn here all about Setting Null Value support in Syncfusion UWP TimePicker (SfTimePicker) control and more.
+title: Setting Null Value in UWP TimePicker control | Syncfusion®
+description: Learn here all about Setting Null Value support in Syncfusion® UWP TimePicker (SfTimePicker) control and more.
 platform: uwp
 control: SfTimePicker
 documentation: ug

--- a/uwp/Timepicker/SfTimeSelector.md
+++ b/uwp/Timepicker/SfTimeSelector.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: SfTimeSelector in UWP TimePicker control | Syncfusion
-description: Learn here all about SfTimeSelector support in Syncfusion UWP TimePicker (SfTimePicker) control and more.
+title: SfTimeSelector in UWP TimePicker control | Syncfusion®
+description: Learn here all about SfTimeSelector support in Syncfusion® UWP TimePicker (SfTimePicker) control and more.
 platform: uwp
 control: SfTimePicker
 documentation: ug

--- a/uwp/Tree-Navigator/Appearance-and-Styling.md
+++ b/uwp/Tree-Navigator/Appearance-and-Styling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Appearance and Styling in UWP Tree Navigator control | Syncfusion
-description: Learn here all about Appearance and Styling support in Syncfusion UWP Tree Navigator (SfTreeNavigator) control and more.
+title: Appearance and Styling in UWP Tree Navigator control | Syncfusion®
+description: Learn here all about Appearance and Styling support in Syncfusion® UWP Tree Navigator (SfTreeNavigator) control and more.
 platform: uwp
 control: SfTreeNavigator
 documentation: ug

--- a/uwp/Tree-Navigator/Getting-Started.md
+++ b/uwp/Tree-Navigator/Getting-Started.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Getting Started with UWP Tree Navigator control | Syncfusion
-description: Learn here about getting started with Syncfusion UWP Tree Navigator (SfTreeNavigator) control, its elements and more.
+title: Getting Started with UWP Tree Navigator control | Syncfusion®
+description: Learn here about getting started with Syncfusion® UWP Tree Navigator (SfTreeNavigator) control, its elements and more.
 platform: uwp
 control: SfTreeNavigator
 documentation: ug

--- a/uwp/Tree-Navigator/Navigation-Mode.md
+++ b/uwp/Tree-Navigator/Navigation-Mode.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Navigation Mode in UWP Tree Navigator control | Syncfusion
-description: Learn here all about Navigation Mode support in Syncfusion UWP Tree Navigator (SfTreeNavigator) control and more.
+title: Navigation Mode in UWP Tree Navigator control | Syncfusion®
+description: Learn here all about Navigation Mode support in Syncfusion® UWP Tree Navigator (SfTreeNavigator) control and more.
 platform: uwp
 control: SfTreeNavigator
 documentation: ug

--- a/uwp/Tree-Navigator/Overview.md
+++ b/uwp/Tree-Navigator/Overview.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: About UWP Tree Navigator control | Syncfusion
-description: Learn here all about introduction of Syncfusion UWP Tree Navigator (SfTreeNavigator) control, its elements and more.
+title: About UWP Tree Navigator control | Syncfusion®
+description: Learn here all about introduction of Syncfusion® UWP Tree Navigator (SfTreeNavigator) control, its elements and more.
 platform: uwp
 control: SfTreeNavigator
 documentation: ug

--- a/uwp/Tree-Navigator/Populating-Items.md
+++ b/uwp/Tree-Navigator/Populating-Items.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Populating Items in UWP Tree Navigator control | Syncfusion
-description: Learn here all about Populating Items support in Syncfusion UWP Tree Navigator (SfTreeNavigator) control and more.
+title: Populating Items in UWP Tree Navigator control | Syncfusion®
+description: Learn here all about Populating Items support in Syncfusion® UWP Tree Navigator (SfTreeNavigator) control and more.
 platform: uwp
 control: SfTreeNavigator
 documentation: ug

--- a/uwp/Tree-Navigator/Selecting-tree-items.md
+++ b/uwp/Tree-Navigator/Selecting-tree-items.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Selecting Items in UWP Tree Navigator control | Syncfusion
-description: Learn here all about Selecting Items support in Syncfusion UWP Tree Navigator (SfTreeNavigator) control and more.
+title: Selecting Items in UWP Tree Navigator control | Syncfusion®
+description: Learn here all about Selecting Items support in Syncfusion® UWP Tree Navigator (SfTreeNavigator) control and more.
 platform: uwp
 control: SfTreeNavigator
 documentation: ug


### PR DESCRIPTION
### Task

[UG documentation 940787](https://dev.azure.com/EssentialStudio/Mobile%20and%20Desktop/_workitems/edit/940787): Include Registered Trademark symbol for all of our tool's controls in WPF, UWP UG

### Task Description
I have included the trademark symbol for Syncfusion , Essential and Essential Studio for the following 

Accordin
Calculator
SfColorPalette
SfColorPicker
SfCombobox
SfDatePicker
SfDockingManager
SfDomainUpDown
SfDropDownButton
SfGroupBar
SfHubTile
SfMaskedEdit
SfMenu
SfMosaicTile
SfProgressBar
SfPulsingTile
SfRadialSlider
SfSpellChecker
SfSplitMosaicTile
SfTabControl
SfTileView
SfTimePicker
SfTreeNavigator

**Note:** We have updated the registered symbol directly in the title and description because using the **sup** tag in a title shows the same text in the URL description.
![image](https://github.com/user-attachments/assets/8ec5d18a-532d-41f6-81a0-4c4687a2e7a3)

**Reference PR :** https://github.com/syncfusion-content/maui-docs/pull/2980/files

### Related PR
https://github.com/syncfusion-content/windowsforms-docs/pull/1141