### PR TITLE
ES-96541 – Modified Code Table for Breaking Changes Solution

### DIFF
--- a/uwp/RichTextBox/Getting-Started.md
+++ b/uwp/RichTextBox/Getting-Started.md
@@ -30,14 +30,16 @@ N> 1. Starting with v16.2.0.41 (2018 Vol 2), if you reference Syncfusion&reg; as
 N> 2. Starting from version v20.3.0.52, we internally disposed all the resources used by SfRichTextBoxAdv instance inside Unloaded event. This change is added to automatically release the memory utilized by SfRichTextBoxAdv instance when it is unloaded. This behavior change may introduce a break if you remove the SfRichTextBoxAdv instance from its parent container and add it to the same or another parent container in your application. In case you used such logic in your application, then kindly add below code before removing the SfRichTextBoxAdv instance from its parent container.
 
 <table>
-<thead>
-    <th>Old code</th>
-    <th>New code</th>
-<thead>
-<tbody>
-  <tr>
-    <td>
-      <pre><code>
+  <thead>
+    <tr>
+      <th>Old code</th>
+      <th>New code</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <pre><code>
 //Remove the control from the parent Grid
 grid.Children.Remove(richTextBoxAdv);
 


### PR DESCRIPTION
Hi Team,

## Issue ##
We’ve introduced some breaking changes in the UWP SfRichTextBoxAdv control. As part of this update, we’ve included the relevant information along with the solution code in a table format.

Currently, this content is maintained in the Getting Started Notes section of the User Guide. However, since the table is rendered as a regular paragraph, it becomes difficult to read and locate the solution effectively.

## Root Cause ##
Due to the improper rendering caused by the disclosure of <thead> tags, the content was not preserved correctly. This pull request includes the necessary code modifications to address this issue.

Regards,
Kalaivannan Ganesan
