### PR TITLE
Charts Getting-Started.md Code Correction - Master

### DIFF
--- a/uwp/Charts/Getting-Started.md
+++ b/uwp/Charts/Getting-Started.md
@@ -230,7 +230,7 @@ N> You need to set [`XBindingPath`](https://help.syncfusion.com/cr/uwp/Syncfusio
 
   <syncfusion:SfChart.SecondaryAxis>
   
-      <syncfusion:NumericalAxis Header="Height(in cm)" >                        
+      <syncfusion:NumericalAxis Header="Height(in cm)" />                        
 
   </syncfusion:SfChart.SecondaryAxis>
     


### PR DESCRIPTION
### Description
This PR adds a code correction to the charts `Getting-Started.md` file in master branch.

#### Changes made
Added the missing self-closing syntax for the NumericalAxis tag in the charts Getting-Started.md file.

Before:
`<syncfusion:NumericalAxis Header="Height(in cm)" >`

After: 
`<syncfusion:NumericalAxis Header="Height(in cm)" />`